### PR TITLE
Enable building jar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.db
 **/target
 *.iml
+*/dependency-reduced-pom.xml

--- a/0-quickie-main/pom.xml
+++ b/0-quickie-main/pom.xml
@@ -3,24 +3,30 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <groupId>org.pinkcrazyunicorn</groupId>
+        <groupId>org.pinkcrazyunicorn.quickie</groupId>
         <artifactId>quickie</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
+    <groupId>org.pinkcrazyunicorn.0-quickie-main</groupId>
     <artifactId>0-quickie-main</artifactId>
+    <version>1.0</version>
+    <packaging>jar</packaging>
+    <name>0-quickie-main</name>
 
     <build>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.1.0</version>
                 <configuration>
-                    <debug>true</debug>
-                    <source>11</source>
-                    <target>11</target>
+                    <archive>
+                        <manifest>
+                            <mainClass>org.pinkcrazyunicorn.Main</mainClass>
+                        </manifest>
+                    </archive>
                 </configuration>
             </plugin>
         </plugins>
@@ -28,29 +34,16 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.pinkcrazyunicorn</groupId>
+            <groupId>org.pinkcrazyunicorn.0-quickie-plugin-cli</groupId>
             <artifactId>0-quickie-plugin-cli</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>1.0</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>org.pinkcrazyunicorn</groupId>
+            <groupId>org.pinkcrazyunicorn.0-quickie-plugin-db</groupId>
             <artifactId>0-quickie-plugin-db</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>1.0</version>
             <scope>compile</scope>
         </dependency>
-        <dependency>
-            <groupId>org.pinkcrazyunicorn</groupId>
-            <artifactId>0-quickie-plugin-scraper</artifactId>
-            <version>1.0-SNAPSHOT</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.pinkcrazyunicorn</groupId>
-            <artifactId>1-quickie-adapters</artifactId>
-            <version>1.0-SNAPSHOT</version>
-            <scope>compile</scope>
-        </dependency>
-
     </dependencies>
 </project>

--- a/0-quickie-plugin-cli/pom.xml
+++ b/0-quickie-plugin-cli/pom.xml
@@ -3,49 +3,35 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <groupId>org.pinkcrazyunicorn</groupId>
+        <groupId>org.pinkcrazyunicorn.quickie</groupId>
         <artifactId>quickie</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
+    <groupId>org.pinkcrazyunicorn.0-quickie-plugin-cli</groupId>
     <artifactId>0-quickie-plugin-cli</artifactId>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
-                <configuration>
-                    <debug>true</debug>
-                    <source>11</source>
-                    <target>11</target>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
+    <version>1.0</version>
+    <packaging>jar</packaging>
+    <name>0-quickie-plugin-cli</name>
 
     <dependencies>
-
         <dependency>
-            <groupId>org.pinkcrazyunicorn</groupId>
+            <groupId>org.pinkcrazyunicorn.1-quickie-adapters</groupId>
             <artifactId>1-quickie-adapters</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>1.0</version>
             <scope>compile</scope>
         </dependency>
-
         <dependency>
             <groupId>commons-cli</groupId>
             <artifactId>commons-cli</artifactId>
             <version>1.5.0</version>
         </dependency>
         <dependency>
-            <groupId>org.pinkcrazyunicorn</groupId>
+            <groupId>org.pinkcrazyunicorn.0-quickie-plugin-db</groupId>
             <artifactId>0-quickie-plugin-db</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>1.0</version>
             <scope>compile</scope>
         </dependency>
-
     </dependencies>
 </project>

--- a/0-quickie-plugin-db/pom.xml
+++ b/0-quickie-plugin-db/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <version>1.4.200</version>
+            <version>2.1.210</version>
         </dependency>
         <dependency>
             <groupId>org.hibernate</groupId>

--- a/0-quickie-plugin-db/pom.xml
+++ b/0-quickie-plugin-db/pom.xml
@@ -3,35 +3,23 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <groupId>org.pinkcrazyunicorn</groupId>
+        <groupId>org.pinkcrazyunicorn.quickie</groupId>
         <artifactId>quickie</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
+    <groupId>org.pinkcrazyunicorn.0-quickie-plugin-db</groupId>
     <artifactId>0-quickie-plugin-db</artifactId>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
-                <configuration>
-                    <debug>true</debug>
-                    <source>11</source>
-                    <target>11</target>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
+    <version>1.0</version>
+    <packaging>jar</packaging>
+    <name>0-quickie-plugin-db</name>
 
     <dependencies>
-
         <dependency>
-            <groupId>org.pinkcrazyunicorn</groupId>
+            <groupId>org.pinkcrazyunicorn.1-quickie-adapters</groupId>
             <artifactId>1-quickie-adapters</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>1.0</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -49,6 +37,16 @@
             <artifactId>javax.persistence</artifactId>
             <version>2.0.0</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>2.17.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.17.1</version>
         </dependency>
     </dependencies>
 </project>

--- a/0-quickie-plugin-db/src/main/resources/META-INF/persistence.xml
+++ b/0-quickie-plugin-db/src/main/resources/META-INF/persistence.xml
@@ -5,8 +5,6 @@
     <persistence-unit name="quickie">
         <provider>org.hibernate.ejb.HibernatePersistence</provider>
 
-        <class>org.pinkcrazyunicorn.jpa.JPAProfile</class>
-
         <properties>
             <property name="hibernate.dialect" value="org.hibernate.dialect.H2Dialect" />
             <property name="javax.persistence.jdbc.driver" value="org.h2.Driver" />

--- a/0-quickie-plugin-db/src/main/resources/log4j2.xml
+++ b/0-quickie-plugin-db/src/main/resources/log4j2.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration>
+    <Loggers>
+        <Logger name="org.hibernate" level="error"/>
+    </Loggers>
+</Configuration>

--- a/0-quickie-plugin-scraper/pom.xml
+++ b/0-quickie-plugin-scraper/pom.xml
@@ -3,37 +3,24 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <groupId>org.pinkcrazyunicorn</groupId>
+        <groupId>org.pinkcrazyunicorn.quickie</groupId>
         <artifactId>quickie</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
+    <groupId>org.pinkcrazyunicorn.0-quickie-plugin-scraper</groupId>
     <artifactId>0-quickie-plugin-scraper</artifactId>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
-                <configuration>
-                    <debug>true</debug>
-                    <source>11</source>
-                    <target>11</target>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
+    <version>1.0</version>
+    <packaging>jar</packaging>
+    <name>0-quickie-plugin-scraper</name>
 
     <dependencies>
-
         <dependency>
-            <groupId>org.pinkcrazyunicorn</groupId>
+            <groupId>org.pinkcrazyunicorn.1-quickie-adapters</groupId>
             <artifactId>1-quickie-adapters</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>1.0</version>
             <scope>compile</scope>
         </dependency>
-
     </dependencies>
 </project>

--- a/1-quickie-adapters/pom.xml
+++ b/1-quickie-adapters/pom.xml
@@ -3,37 +3,24 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <groupId>org.pinkcrazyunicorn</groupId>
+        <groupId>org.pinkcrazyunicorn.quickie</groupId>
         <artifactId>quickie</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
+    <groupId>org.pinkcrazyunicorn.1-quickie-adapters</groupId>
     <artifactId>1-quickie-adapters</artifactId>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
-                <configuration>
-                    <debug>true</debug>
-                    <source>11</source>
-                    <target>11</target>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
+    <version>1.0</version>
+    <packaging>jar</packaging>
+    <name>1-quickie-adapters</name>
 
     <dependencies>
-
         <dependency>
-            <groupId>org.pinkcrazyunicorn</groupId>
+            <groupId>org.pinkcrazyunicorn.2-quickie-application</groupId>
             <artifactId>2-quickie-application</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>1.0</version>
             <scope>compile</scope>
         </dependency>
-
     </dependencies>
 </project>

--- a/2-quickie-application/pom.xml
+++ b/2-quickie-application/pom.xml
@@ -3,37 +3,24 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <groupId>org.pinkcrazyunicorn</groupId>
+        <groupId>org.pinkcrazyunicorn.quickie</groupId>
         <artifactId>quickie</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
+    <groupId>org.pinkcrazyunicorn.2-quickie-application</groupId>
     <artifactId>2-quickie-application</artifactId>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
-                <configuration>
-                    <debug>true</debug>
-                    <source>11</source>
-                    <target>11</target>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
+    <version>1.0</version>
+    <packaging>jar</packaging>
+    <name>2-quickie-application</name>
 
     <dependencies>
-
         <dependency>
-            <groupId>org.pinkcrazyunicorn</groupId>
+            <groupId>org.pinkcrazyunicorn.3-quickie-domain</groupId>
             <artifactId>3-quickie-domain</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>1.0</version>
             <scope>compile</scope>
         </dependency>
-
     </dependencies>
 </project>

--- a/3-quickie-domain/pom.xml
+++ b/3-quickie-domain/pom.xml
@@ -3,27 +3,16 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <groupId>org.pinkcrazyunicorn</groupId>
+        <groupId>org.pinkcrazyunicorn.quickie</groupId>
         <artifactId>quickie</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
+    <groupId>org.pinkcrazyunicorn.3-quickie-domain</groupId>
     <artifactId>3-quickie-domain</artifactId>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
-                <configuration>
-                    <debug>true</debug>
-                    <source>11</source>
-                    <target>11</target>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
+    <version>1.0</version>
+    <packaging>jar</packaging>
+    <name>3-quickie-domain</name>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -4,10 +4,10 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.pinkcrazyunicorn</groupId>
+    <groupId>org.pinkcrazyunicorn.quickie</groupId>
     <artifactId>quickie</artifactId>
     <packaging>pom</packaging>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0</version>
 
     <properties>
         <maven.compiler.source>11</maven.compiler.source>
@@ -26,16 +26,43 @@
     </modules>
 
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.8.0</version>
+                    <configuration>
+                        <source>11</source>
+                        <target>11</target>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
-                <configuration>
-                    <debug>true</debug>
-                    <source>11</source>
-                    <target>11</target>
-                </configuration>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.4</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>org.pinkcrazyunicorn.Main</mainClass>
+                                    <manifestEntries>
+                                        <Multi-Release>true</Multi-Release>
+                                    </manifestEntries>
+                                </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Builden in IntelliJ sollte jetzt mit `Maven -> quickie (root) -> package` gehen.
Die fertige jar sollte dann unter 0-quickie-main/target/0-quickie-main-1.0.jar zu finden sein.